### PR TITLE
feat(size): calculate and verify the size of the 3DLUT

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@
 
         <label for="lutSize">LUT Size:</label>
         <select id="lutSize">
+          <option value="auto">Auto</option>
           <option value="17">17</option>
           <option value="33">33</option>
           <option value="65">65</option>


### PR DESCRIPTION
J'ai mis une petite fonction qui calcule la taille de la LUT, du coup c'est possible de mettre le champ **LUT Size** en `auto`, c'est intéressant ?
Il y aussi une petite alerte si jamais la ligne `LUT_3D_SIZE` ne correspond pas.

Une amélioration possible serait de vérifier la taille de la LUT quand l'utilisateur choisi une taille manuellement, pour le prévenir qu'il s'est potentiellement trompé.